### PR TITLE
Query for binlog position instead of streaming tables for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a simple interface for calling a function in response to a MySQL binlog event.
              :port      3308
              :db        "tailer"
              :server-id 5
-             :tables    [:users]})
+             :tables    #{users}})
 
 (defn handler
   [[op table id content metadata]]

--- a/bin/mysql
+++ b/bin/mysql
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run -it --rm --name binlog-test -p "3308:3306" -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tailer mysql:5.6 --log-bin --server-id=5 --binlog_format=ROW
+docker run --platform linux/x86_64 -it --rm --name binlog-test -p "3308:3306" -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=tailer mysql:5.6 --log-bin --server-id=5 --binlog_format=ROW

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -8,7 +8,8 @@
              :port      3308
              :db        "tailer"
              :server-id 5
-             :tables    [:users]})
+             :tables    #{:users}
+             :callbacks {:on-disconnect #(println "disconnected")}})
 
 (def handler (fn [[op table id content metadata]]
                (println (str "Operation: " op))

--- a/src/teamgantt/binlog_tailer/spec.clj
+++ b/src/teamgantt/binlog_tailer/spec.clj
@@ -21,7 +21,7 @@
 
 (s/def ::table keyword?)
 
-(s/def ::tables (s/coll-of ::table :kind vector?))
+(s/def ::tables (s/coll-of ::table :kind set?))
 
 (s/def ::callbacks (s/map-of ::event fn?))
 


### PR DESCRIPTION
This makes the binlog tailer truly an event stream. It no longer does a table scan in order to start streaming events. More appropriate for what this is designed to do.

`:tables` in config is now a `set` instead of a `vector`. 

The dockerized mysql instance sets the platform when running from `bin/` - this was necessary to be able to party on an M1