### PR TITLE
update to MySQL 8

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure  {:mvn/version "1.10.3"}
-         io.github.teamgantt/dumpa  {:git/sha "4453ca0d193d91f834a1ab78d1438d8ebc5b7402"}}
+         io.github.teamgantt/dumpa  {:git/sha "a811053feea8e629d0cd7951836924b8f40ccf67"}}
  :aliases
  {:dev     {:extra-paths ["dev/src"]
             :extra-deps  {mount/mount {:mvn/version "0.1.16"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure  {:mvn/version "1.10.3"}
-         com.teamgantt/dumpa  {:mvn/version "0.0.3"}}
+         io.github.teamgantt/dumpa  {:git/sha "4453ca0d193d91f834a1ab78d1438d8ebc5b7402"}}
  :aliases
  {:dev     {:extra-paths ["dev/src"]
             :extra-deps  {mount/mount {:mvn/version "0.1.16"}}}

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,6 @@
       <artifactId>clojure</artifactId>
       <version>1.10.3</version>
     </dependency>
-    <dependency>
-      <groupId>com.teamgantt</groupId>
-      <artifactId>dumpa</artifactId>
-      <version>0.0.3</version>
-    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>


### PR DESCRIPTION
This switches `binlogtailer` to use a git sha for `dumpa`. The sha will need to be updated before merging this PR - once this PR merges: https://github.com/teamgantt/dumpa/pull/9